### PR TITLE
Update README.rst to better reflect repository purpose

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Package
 
 .. end-badges
 
-Tiny tools of the oemof project.
+Tiny tools used for the development of oemof packages.
 
 * Free software: MIT license
 

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Package
 
 .. end-badges
 
-Tiny tools used for the development of oemof packages.
+Tiny tools used mainly for the development of oemof packages.
 
 * Free software: MIT license
 


### PR DESCRIPTION
According to the discussion at the dev meeting 2025, the one-liner is adapted to better reflect that oemof-tools is used in many different packages of oemof, mainly for developement purposes.